### PR TITLE
Switch FROM to official pytorch docker image

### DIFF
--- a/em-tweet-filter/Dockerfile
+++ b/em-tweet-filter/Dockerfile
@@ -1,12 +1,27 @@
-FROM pytorch/pytorch
+FROM tensorflow/tensorflow:1.9.0-rc0-gpu-py3
 
 MAINTAINER Jeremy Diaz <jeremy.diaz@colorado.edu>
 
-RUN apt-get update && \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	git \
+	libtcmalloc-minimal4 && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip install jupyter tweepy nltk gensim xlrd botometer livelossplot
+ENV LD_PRELOAD /usr/lib/libtcmalloc_minimal.so.4
+
+RUN pip3 install awscli \
+	botometer \
+	gensim \
+	livelossplot \
+	nltk \
+	pandas \
+	pybind11 \
+	scikit-learn \
+	scipy \
+	torch \
+	tweepy \
+	xlrd
 
 RUN git clone https://github.com/facebookresearch/fastText.git && \
 	cd fastText && \
@@ -17,3 +32,4 @@ EXPOSE 8888
 WORKDIR "/home/"
 
 CMD ["/run_jupyter.sh", "--allow-root"]
+

--- a/em-tweet-filter/Dockerfile
+++ b/em-tweet-filter/Dockerfile
@@ -1,4 +1,4 @@
-FROM earthlab/pytorch-gpu-aws
+FROM pytorch/pytorch
 
 MAINTAINER Jeremy Diaz <jeremy.diaz@colorado.edu>
 
@@ -6,7 +6,7 @@ RUN apt-get update && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip install tweepy nltk gensim xlrd botometer livelossplot
+RUN pip install jupyter tweepy nltk gensim xlrd botometer livelossplot
 
 RUN git clone https://github.com/facebookresearch/fastText.git && \
 	cd fastText && \

--- a/em-tweet-filter/Dockerfile
+++ b/em-tweet-filter/Dockerfile
@@ -23,13 +23,13 @@ RUN pip3 install awscli \
 	tweepy \
 	xlrd
 
+WORKDIR "/home/"
+
 RUN git clone https://github.com/facebookresearch/fastText.git && \
 	cd fastText && \
 	pip install .
 
 EXPOSE 8888
-
-WORKDIR "/home/"
 
 CMD ["/run_jupyter.sh", "--allow-root"]
 

--- a/em-tweet-filter/README.md
+++ b/em-tweet-filter/README.md
@@ -12,7 +12,7 @@ This image requires that the NVIDIA drivers and nvidia-docker are installed on t
 To run, the image and interface with the Jupyter Notebook:
 
 ```
-nvidia-docker run -it -p 8888:8888 earthlab/em-tweet-filter
+nvidia-docker run -it -p 8888:8888 --hostname localhost earthlab/em-tweet-filter
 ```    
 
 You can then view the Jupyter Notebook by opening `http://localhost:8888` in your web browser.<br><br><br>

--- a/r-reidgroup/Dockerfile
+++ b/r-reidgroup/Dockerfile
@@ -60,6 +60,19 @@ RUN install2.r --error \
 RUN pip install wheel \ 
   && pip install awscli
 
+# install wgrib2
+RUN wget ftp://ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz && \
+  tar -xzvf wgrib2.tgz
+
+WORKDIR grib2
+
+RUN export CC=gcc && \
+  export FC=gfortran && \
+  make && \
+  make lib 
+
+RUN install2.r --error rNOMADS
+
 EXPOSE 8787
 
 CMD ["/init"]

--- a/r-reidgroup/README.md
+++ b/r-reidgroup/README.md
@@ -1,0 +1,22 @@
+# r-reidgroup
+
+Docker container with R, RStudio, various spatial packages, and the tidyverse.
+
+## How to use
+
+Download and run this image using the following commands:
+
+To use Rstudio:
+
+```
+docker run -d -p 8787:8787 earthlab/r-reidgroup
+```
+
+In a web browser, navigate to localhost:8787 (on linux) or on a Mac, substitute the location pointed to by `docker-machine ip default` for `localhost`.
+Log in with username: rstudio, password: rstudio.
+
+## Mounting folders
+
+If you want to share a directory between your host machine and the container, use the `-v` flag in your call to `docker run`, as described [here](https://github.com/rocker-org/rocker/wiki/Sharing-files-with-host-machine).
+For more information on how to take full advantage of RStudio in this image, see https://github.com/rocker-org/rocker/wiki/Using-the-RStudio-image.
+


### PR DESCRIPTION
I've removed our old pytorch GPU image, now that the pytorch devs have an official pytorch Docker image. That's imported as the parent image for the em-tweet-filter now. Maybe have a peek @jdiaz4302 and merge if you don't find any issues (not sure whether you're still using this image, or switched to installing everything directly in an EC2 instance instead). 